### PR TITLE
Update Readme.md to explain how to install keyble as a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,25 @@ For example, if you have the *mosquitto-clients* tools installed *(`sudo apt-get
 
 Assuming a MQTT broker with IP address 192.168.0.2, sending message "open" to the MQTT topic "door_lock/action" for example would then open the Smart Lock; changes to the door lock status would be automatically published as retained messages to MQTT topic "door_lock/status".
 
+#### Installing as a mqtt-service
+A scenario may be to run keyble on a single board computer (e.g. Raspberry Pi Zero). For this, it is needed to start the above mosquitto -> keyble-sendcommand -> mosquitto chain at boot.
+For this, two files are needed:
+* `/etc/systemd/system/Smartlock.service`  - The systemd service
+* `/usr/local/bin/Smartlock.sh`  - The script that is run by the service.
+
+Both files are available in this github (under ./scripts/). The first file does not need to be edited. In the second file (the script), the mqtt-server ip, the address of the lock, the key and the user_id need to be configured.
+
+*To install the service:*
+* Download both files and put them at the correct location
+* Edit the script with your credentials
+* Make sure that the script is executable (`chmod u+x /usr/local/bin/Smartlock.sh`)
+* Start the service:
+`sudo systemctl start Smartlock`
+
+* Enable it to run at boot:
+`sudo systemctl enable Smartlock`
+
+
 ## API
 
 Beware that since *keyble* is still in early alpha state, the API is likely to still change a lot, probably with backwards-incompatible changes. Only a subset of the functionality has been documented yet, and only a few usage examples are provided.


### PR DESCRIPTION
Update Readme.md to explain how to install keyble as a service.

The required files were provided in two other PRs