### PR TITLE
Add noble dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "aes-js": "^3.1.2",
     "argparse": "^1.0.10",
     "debug": "^4.1.1",
-    "simble": "^0.2.3"
+    "simble": "^0.2.3",
+    "noble": "^1.9.1"
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
**Add noble dependency in package.json**

When getting the following error after *keyble* installation, it means that *noble* has not been installed.

```
$ keyble-registeruser
module.js:550
    throw err;
    ^

Error: Cannot find module 'noble'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/usr/lib/node_modules/keyble/node_modules/simble/simble.js:138:9)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
```

The failing instruction is:

```
noble = require('noble');
```

To install *noble*:

```
sudo apt-get install bluetooth bluez libbluetooth-dev libudev-dev
sudo npm install --unsafe-perm --update --global noble
```

Alternatively, this patch adds *noble* dependency in *package.json*.